### PR TITLE
Adds script and use description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # aws-sso-role-credentials
 Fetch AWS SSO role credentials using cached token
+
+## Setup
+- Place `aws_sso_role_credentials` into a folder within your `PATH`.  
+- Make the script executable, e.g. `chmod +x aws_sso_role_credentials`.  
+
+## Usage
+- Ensure you have a current sso session. One may be created with `aws sso login --profile <valid name of profile in ~/.aws/config>`
+- Run `aws_sso_role_credentials <valid name of profile in ~/.aws/config>`
+
+A current set of credentials for the specified profile (access key, secret access key, and session token) should now be present in `~/.aws/credentials` with the same profile name

--- a/aws_sso_role_credentials
+++ b/aws_sso_role_credentials
@@ -1,0 +1,35 @@
+#!/usr/bin/ruby
+# frozen_string_literal: true
+
+require 'json'
+require 'time'
+require 'parseconfig'
+require 'pathname'
+
+# Reads profile info from config file
+config = ParseConfig.new(Pathname('~/.aws/config').expand_path)
+profile_config = config["profile #{ARGV[0]}"]
+
+# Finds current session, checks if expired
+cache = Dir[Pathname('~/.aws/sso/cache/*.json').expand_path]
+        .map(&method(:Pathname)).map(&:read).map(&JSON.method(:parse)).find { |blob|
+  blob['startUrl'] == profile_config['sso_start_url']
+}
+
+raise ArgumentError, 'expired sso session' if Time.parse(cache['expiresAt']) < Time.now
+
+# Retrieves new credentials
+cred_resp = `aws sso get-role-credentials --profile #{ARGV[0]} --role-name #{profile_config['sso_role_name']} --account-id #{profile_config['sso_account_id']} --access-token #{cache['accessToken']} --region #{profile_config['region']}`
+role_creds = JSON.parse(cred_resp)['roleCredentials']
+
+profile_creds = {
+  'aws_access_key_id' => role_creds['accessKeyId'],
+  'aws_secret_access_key' => role_creds['secretAccessKey'],
+  'aws_session_token' => role_creds['sessionToken']
+}
+credentials_path = Pathname('~/.aws/credentials').expand_path
+credentials = ParseConfig.new(credentials_path)
+
+# Saves new credentials to specified profile name (will over-write previous values)
+credentials.add(ARGV[0], profile_creds)
+credentials.write(credentials_path.open('w'), quoted = false)


### PR DESCRIPTION
What this PR does:
Adds instructions for use in README
Adds the actual script code.
Changes from  original @matchbookmac script:
- Comments added
- Profile name is now user defined (by arg passed to script)
- Credentials are no longer quoted

What this PR doesn't do:
`parseconfig` is not in the Ruby SL. Either a note of this should be made in the README or a Gemfile should be added with README description